### PR TITLE
Adds system colors scheme and hover on buttons

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.6.1"
   bitsdojo_window:
     dependency: "direct main"
     description:
@@ -70,7 +70,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
@@ -137,6 +137,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  from_css_color:
+    dependency: transitive
+    description:
+      name: from_css_color
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   gsettings:
     dependency: transitive
     description:
@@ -171,7 +178,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.3.0"
   more:
     dependency: transitive
     description:
@@ -206,7 +213,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.1.0"
   platform:
     dependency: transitive
     description:
@@ -274,7 +281,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -309,7 +316,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.1.2"
 sdks:
   dart: ">=2.13.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/lib/src/utils/gtk_colors.dart
+++ b/lib/src/utils/gtk_colors.dart
@@ -1,6 +1,85 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 
+import 'dart:io';
+import 'dart:ui';
+import 'package:from_css_color/from_css_color.dart';
+import 'package:gsettings/gsettings.dart';
+
+class GnomeTheme {
+  String contents = "";
+
+  Color? themeBgColor;
+  Color? textColor;
+  Color? buttonFg;
+  Color? themeBaseColor;
+  Color? insensitiveBgColor;
+  // Border of widgets not text inputs fields
+  Color? unfocusedBorder;
+  Color? border;
+  Color? themeSelectedBG;
+  Color? textSelectedFG;
+
+  GnomeTheme() {
+    loadFromFile();
+    parse();
+  }
+
+  void loadFromFile() {
+    final settings = GSettings(schemaId: 'org.gnome.desktop.interface');
+    final theme = settings.stringValue('gtk-theme');
+    String fileName = "/usr/share/themes/" + theme + "/gtk-3.0/gtk.css";
+    File file = File(fileName);
+    if (file.existsSync()) {
+      contents = File(fileName).readAsStringSync();
+    }
+  }
+
+  ThemeData data(context) {
+    ThemeData themedata = ThemeData(
+        iconTheme: IconThemeData(color: textColor),
+        brightness: Brightness.dark,
+        canvasColor: themeBgColor,
+        textSelectionTheme: TextSelectionThemeData(cursorColor: textColor),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+            style: ElevatedButton.styleFrom(
+                primary: buttonFg, onPrimary: textColor)),
+        textTheme: TextTheme(
+            bodyText2: TextStyle(color: textColor),
+            bodyText1: TextStyle(color: textColor)),
+        primaryColor: themeBaseColor);
+    return themedata.copyWith(
+        colorScheme: themedata.colorScheme.copyWith(secondary: textColor));
+  }
+
+  /// Get standard gtk color define
+  Color? getBaseColor(String colorName) {
+    String demand = "(@define-color " + colorName + " )(.*);";
+    RegExp exp = RegExp(demand);
+
+    RegExpMatch? matches = exp.firstMatch(contents);
+    String? color = matches?.group(2).toString();
+    if (color != null) {
+      return fromCssColor(color);
+    }
+    return null;
+  }
+
+  void parse() {
+    themeBgColor = getBaseColor("theme_base_color");
+    textColor = getBaseColor("theme_text_color");
+    buttonFg = getBaseColor("button_fg_color");
+    themeBaseColor = getBaseColor("theme_base_color");
+    insensitiveBgColor = getBaseColor("insensitive_bg_color");
+    unfocusedBorder = getBaseColor("unfocused_borders");
+    border = getBaseColor("borders");
+    themeSelectedBG = getBaseColor("theme_selected_bg_color");
+    textSelectedFG = getBaseColor("theme_selected_fg_color");
+
+    buttonFg ??= themeBgColor;
+  }
+}
+
 getGtkColor({
   required GtkColorType colorType,
   required bool isDark,
@@ -9,6 +88,11 @@ getGtkColor({
   switch (colorTheme) {
     case GtkColorTheme.adwaita:
       return _adwaita(isDark)[describeEnum(colorType)];
+    case GtkColorTheme.system:
+      var theme = GnomeTheme();
+      theme.loadFromFile();
+      theme.parse();
+      return _system(theme)[describeEnum(colorType)];
   }
 }
 
@@ -20,6 +104,7 @@ getAdaptiveGtkColor(
     getGtkColor(
       colorType: colorType,
       isDark: Theme.of(context).brightness == Brightness.dark,
+      colorTheme: colorTheme,
     );
 
 enum GtkColorType {
@@ -31,6 +116,8 @@ enum GtkColorType {
   headerBarBottomBorder,
   headerButtonBackgroundTop,
   headerButtonBackgroundBottom,
+  headerButtonBackgroundTopHover,
+  headerButtonBackgroundBottomHover,
   headerButtonBorder,
   headerButtonPrimary,
   headerSwitcherTabPrimary,
@@ -40,6 +127,46 @@ enum GtkColorType {
 
 enum GtkColorTheme {
   adwaita,
+  system,
+}
+
+Map<String, Color> _system(GnomeTheme theme) {
+  return {
+    'windowControlIconColor':
+        theme.buttonFg != null ? theme.buttonFg! : const Color(0xFFF9F8F8),
+    'canvas': theme.themeBgColor != null
+        ? theme.themeBgColor!
+        : const Color(0xFFF9F8F8),
+    'headerBarBackgroundTop': theme.themeBgColor != null
+        ? theme.themeBgColor!
+        : const Color(0xFFF9F8F8),
+    'headerBarBackgroundBottom': theme.themeBgColor != null
+        ? theme.themeBgColor!
+        : const Color(0xFFF9F8F8),
+    'headerBarTopBorder':
+        theme.border != null ? theme.border! : const Color(0xFFF9F8F8),
+    'headerBarBottomBorder':
+        theme.border != null ? theme.border! : const Color(0xFFF9F8F8),
+    'headerButtonBackgroundTop':
+        theme.buttonFg != null ? theme.buttonFg! : const Color(0xFFF9F8F8),
+    'headerButtonBackgroundBottom':
+        theme.buttonFg != null ? theme.buttonFg! : const Color(0xFFF9F8F8),
+    'headerButtonBackgroundTopHover': theme.themeSelectedBG != null
+        ? theme.themeSelectedBG!.withOpacity(0.2)
+        : const Color(0xFFF9F8F8),
+    'headerButtonBackgroundBottomHover': theme.themeSelectedBG != null
+        ? theme.themeSelectedBG!.withOpacity(0.2)
+        : const Color(0xFFF9F8F8),
+    'headerButtonBorder': theme.unfocusedBorder != null
+        ? theme.unfocusedBorder!
+        : const Color(0xFFF9F8F8),
+    'headerButtonPrimary':
+        theme.buttonFg != null ? theme.buttonFg! : const Color(0xFFF9F8F8),
+    'headerSwitcherTabPrimary':
+        theme.buttonFg != null ? theme.buttonFg! : const Color(0xFFF9F8F8),
+    'headerSwitcherTabBackground': const Color(0xFFD5D1CD),
+    'headerSwitcherTabBorder': const Color(0xFFCDC7C2),
+  };
 }
 
 Map<String, Color> _adwaita(bool isDark) {
@@ -58,6 +185,10 @@ Map<String, Color> _adwaita(bool isDark) {
     'headerButtonBackgroundTop':
         isDark ? const Color(0xFF383838) : const Color(0xFFF6F5F3),
     'headerButtonBackgroundBottom':
+        isDark ? const Color(0xFF333333) : const Color(0xFFEEECEA),
+    'headerButtonBackgroundTopHover':
+        isDark ? const Color(0xFF383838) : const Color(0xFFF6F5F3),
+    'headerButtonBackgroundBottomHover':
         isDark ? const Color(0xFF333333) : const Color(0xFFEEECEA),
     'headerButtonBorder':
         isDark ? const Color(0xFF1B1B1B) : const Color(0xFFCEC8C3),

--- a/lib/src/widgets/gtk_header_bar.dart
+++ b/lib/src/widgets/gtk_header_bar.dart
@@ -27,6 +27,8 @@ class GtkHeaderBar extends StatelessWidget {
   /// The theme to use for the titlerbar/window buttons
   final ThemeType themeType;
 
+  final GtkColorTheme systemTheme;
+
   const GtkHeaderBar({
     Key? key,
     required this.appWindow,
@@ -34,6 +36,7 @@ class GtkHeaderBar extends StatelessWidget {
     this.center = const SizedBox(),
     this.trailling = const SizedBox(),
     this.themeType = ThemeType.auto,
+    this.systemTheme = GtkColorTheme.adwaita,
     this.onMinimize,
     this.onMaximize,
     this.onClose,
@@ -59,10 +62,12 @@ class GtkHeaderBar extends StatelessWidget {
                 getAdaptiveGtkColor(
                   context,
                   colorType: GtkColorType.headerBarBackgroundTop,
+                  colorTheme: systemTheme,
                 ),
                 getAdaptiveGtkColor(
                   context,
                   colorType: GtkColorType.headerBarBackgroundBottom,
+                  colorTheme: systemTheme,
                 ),
               ],
             ),
@@ -71,12 +76,14 @@ class GtkHeaderBar extends StatelessWidget {
                 color: getAdaptiveGtkColor(
                   context,
                   colorType: GtkColorType.headerBarTopBorder,
+                  colorTheme: systemTheme,
                 ),
               ),
               bottom: BorderSide(
                 color: getAdaptiveGtkColor(
                   context,
                   colorType: GtkColorType.headerBarBottomBorder,
+                  colorTheme: systemTheme,
                 ),
               ),
             ),

--- a/lib/src/widgets/gtk_header_button.dart
+++ b/lib/src/widgets/gtk_header_button.dart
@@ -1,63 +1,117 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import '../utils/utils.dart';
 
-class GtkHeaderButton extends StatelessWidget {
-  /// The icon of the button
+class GtkHeaderButton extends StatefulWidget {
   final Widget icon;
-
-  /// The background color for the button
-  final Color? color;
 
   /// Triggered when the button is pressed.
   final VoidCallback? onPressed;
 
+  final GtkColorTheme systemTheme;
+
   const GtkHeaderButton({
     Key? key,
-    this.color,
     required this.icon,
+    this.systemTheme = GtkColorTheme.adwaita,
     this.onPressed,
   }) : super(key: key);
 
   @override
+  _GtkHeaderButtonState createState() => _GtkHeaderButtonState(
+      icon: icon, systemTheme: systemTheme, onPressed: onPressed);
+}
+
+class _GtkHeaderButtonState extends State<GtkHeaderButton> {
+  bool hovering = false;
+
+  /// The icon of the button
+  final Widget icon;
+
+  /// Triggered when the button is pressed.
+  final VoidCallback? onPressed;
+
+  final GtkColorTheme systemTheme;
+
+  _GtkHeaderButtonState({
+    required this.icon,
+    this.systemTheme = GtkColorTheme.adwaita,
+    this.onPressed,
+  });
+
+  @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 34,
-      width: 36,
-      margin: const EdgeInsets.symmetric(horizontal: 6),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(5),
-        border: Border.all(
-          color: getAdaptiveGtkColor(
-            context,
-            colorType: GtkColorType.headerButtonBorder,
+    return MouseRegion(
+        onExit: _removeColor,
+        onHover: _updateColor,
+        child: Container(
+          height: 34,
+          width: 36,
+          margin: const EdgeInsets.symmetric(horizontal: 6),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(5),
+            border: Border.all(
+              color: getAdaptiveGtkColor(
+                context,
+                colorType: GtkColorType.headerButtonBorder,
+                colorTheme: systemTheme,
+              ),
+            ),
+            gradient: hovering
+                ? LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      getAdaptiveGtkColor(
+                        context,
+                        colorType:
+                            GtkColorType.headerButtonBackgroundBottomHover,
+                        colorTheme: systemTheme,
+                      ),
+                      getAdaptiveGtkColor(
+                        context,
+                        colorType: GtkColorType.headerButtonBackgroundTopHover,
+                        colorTheme: systemTheme,
+                      ),
+                    ],
+                  )
+                : LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      getAdaptiveGtkColor(
+                        context,
+                        colorType: GtkColorType.headerButtonBackgroundBottom,
+                        colorTheme: systemTheme,
+                      ),
+                      getAdaptiveGtkColor(
+                        context,
+                        colorType: GtkColorType.headerButtonBackgroundTop,
+                        colorTheme: systemTheme,
+                      ),
+                    ],
+                  ),
           ),
-        ),
-        color: color,
-        gradient: color == null
-            ? LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  getAdaptiveGtkColor(
-                    context,
-                    colorType: GtkColorType.headerBarBackgroundBottom,
-                  ),
-                  getAdaptiveGtkColor(
-                    context,
-                    colorType: GtkColorType.headerBarBackgroundTop,
-                  ),
-                ],
-              )
-            : null,
-      ),
-      child: IconButton(
-        icon: icon,
-        hoverColor: Colors.transparent,
-        splashColor: Colors.transparent,
-        focusColor: Colors.transparent,
-        highlightColor: Colors.transparent,
-        onPressed: onPressed,
-      ),
-    );
+          child: IconButton(
+            icon: icon,
+            hoverColor: Colors.transparent,
+            splashColor: Colors.transparent,
+            focusColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            onPressed: onPressed,
+          ),
+        ));
+  }
+
+  void _updateColor(PointerHoverEvent ev) {
+    setState(() {
+      hovering = true;
+    });
+  }
+
+  void _removeColor(PointerExitEvent ev) {
+    setState(() {
+      hovering = false;
+    });
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   adwaita_icons:
   popover:
   window_decorations:
+  gsettings: ^0.1.2+1
+  from_css_color: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi thanks for doing a good gtk/flutter package.

I started to do something similar a couple of months ago, but I cannot maintain or finish it. I've tried porting some of the stuff I did to your library, and  would like to know what you think of it, but it might not be the cleanest code for now (sorry about that). If it seems interesting to you, I could clean up the code a bit for a better merge request.

It basically adds a class able to "parse" the color of the gtk theme enabled (even if other than Adwaita) and apply it generally and the whole app through the theme attributes of MaterialApp.
Furthermore, I have added a parameter to the headerbar and headerbutton to use either default Adwaita or the system colors parse by GnomeTheme.
Finally, the commit adds hover to the header buttons.