### PR TITLE
Provider to provide theme to all elements

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:gtk/gtk.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:window_decorations/window_decorations.dart';
+import 'package:provider/provider.dart';
 
 void main() => runApp(const MyApp());
 
@@ -10,13 +11,13 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var theme = GnomeTheme();
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: theme.data(context),
-      debugShowCheckedModeBanner: false,
-      home: const MyHomePage(title: 'Gtk + Flutter Demo'),
-    );
+    return GtkApp(builder: (context, widget) {
+      return MaterialApp(
+          title: 'Flutter Demo',
+          debugShowCheckedModeBanner: false,
+          home: const MyHomePage(title: 'Gtk + Flutter Demo'),
+          theme: Provider.of<GnomeThemeProvider>(context).getTheme());
+    });
   }
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -179,6 +179,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -242,6 +249,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.3"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/gtk.dart
+++ b/lib/gtk.dart
@@ -3,3 +3,4 @@ library gtk;
 export 'src/models/models.dart';
 export 'src/utils/utils.dart';
 export 'src/widgets/widgets.dart';
+export 'src/providers/theme_provider.dart';

--- a/lib/src/providers/theme_provider.dart
+++ b/lib/src/providers/theme_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:gtk/gtk.dart';
+
+class GnomeThemeProvider with ChangeNotifier {
+  GnomeTheme theme = GnomeTheme();
+
+  GnomeThemeProvider() {
+    load();
+  }
+
+  Future<void> load() async {
+    await theme.loadFromFile();
+    theme.parse();
+    notifyListeners();
+  }
+
+  ThemeData getTheme() => theme.themeData;
+}

--- a/lib/src/utils/gtk_colors.dart
+++ b/lib/src/utils/gtk_colors.dart
@@ -23,8 +23,14 @@ class GnomeTheme {
   Color? border;
   Color? themeSelectedBG;
   Color? textSelectedFG;
+  Color headerBarBackgroundTop = const Color(0xFFE1DEDB);
+  Color headerBarBackgroundBottom = const Color(0xFFDAD6D2);
+  Color headerBarBottomBorder = const Color(0xFFBFB8B1);
+
+  late ThemeData themeData;
 
   GnomeTheme() {
+    themeData = adwaita();
     loadFromFile();
     parse();
   }
@@ -52,11 +58,21 @@ class GnomeTheme {
     }
   }
 
-  ThemeData data(context) {
-    ThemeData themedata = ThemeData(
+  ThemeData adwaita() {
+    headerBarBackgroundTop = const Color(0xFFE1DEDB);
+    headerBarBackgroundBottom = const Color(0xFFDAD6D2);
+    headerBarBottomBorder = const Color(0xFFBFB8B1);
+    themeData = ThemeData(
+      brightness: Brightness.light,
+    );
+    return themeData;
+  }
+
+  ThemeData data() {
+    themeData = ThemeData(
       iconTheme: IconThemeData(color: textColor),
-      brightness: textColor != null
-          ? textColor!.computeLuminance() <= 0.5
+      brightness: themeBgColor != null
+          ? themeBgColor!.computeLuminance() >= 0.5
               ? Brightness.light
               : Brightness.dark
           : null,
@@ -70,8 +86,9 @@ class GnomeTheme {
           bodyText1: TextStyle(color: textColor)),
       primaryColor: themeBaseColor,
     );
-    return themedata.copyWith(
-        colorScheme: themedata.colorScheme.copyWith(secondary: textColor));
+    themeData = themeData.copyWith(
+        colorScheme: themeData.colorScheme.copyWith(secondary: textColor));
+    return themeData;
   }
 
   /// Get standard gtk color define
@@ -107,7 +124,16 @@ class GnomeTheme {
     themeSelectedBG = getBaseColor("theme_selected_bg_color");
     textSelectedFG = getBaseColor("theme_selected_fg_color");
 
+    if (themeBgColor != null) {
+      headerBarBackgroundTop = themeBgColor!;
+      headerBarBackgroundBottom = themeBgColor!;
+    }
+    if (border != null) {
+      headerBarBottomBorder = border!;
+    }
+
     buttonFg ??= themeBgColor;
+    data();
   }
 }
 

--- a/lib/src/widgets/gtk_app.dart
+++ b/lib/src/widgets/gtk_app.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:gtk/src/providers/theme_provider.dart';
+import 'package:provider/provider.dart';
+
+class GtkApp extends StatelessWidget {
+  final TransitionBuilder? builder;
+
+  const GtkApp({required this.builder, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<GnomeThemeProvider>(
+        create: (_) => GnomeThemeProvider(), builder: builder);
+  }
+}

--- a/lib/src/widgets/gtk_header_bar.dart
+++ b/lib/src/widgets/gtk_header_bar.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:gtk/gtk.dart';
-import '../utils/utils.dart';
 
 /// Use GtkHeaderBarMinimal for HeaderBar without window_decorations package
 class GtkHeaderBar extends StatelessWidget {
@@ -24,8 +23,6 @@ class GtkHeaderBar extends StatelessWidget {
 
   /// The ThemeType property from windowDecoration package to use for the titlerbar/window buttons
   final dynamic themeType;
-
-  final GtkColorTheme systemTheme;
 
   /// The height of the headerbar
   final double height;
@@ -65,7 +62,6 @@ class GtkHeaderBar extends StatelessWidget {
     this.titlebarSpace = 4,
     this.height = 47,
     this.themeType,
-    this.systemTheme = GtkColorTheme.adwaita,
     this.onMinimize,
     this.onMaximize,
     this.onClose,
@@ -84,7 +80,6 @@ class GtkHeaderBar extends StatelessWidget {
     this.titlebarSpace = 4,
     this.height = 47,
     this.themeType,
-    this.systemTheme = GtkColorTheme.adwaita,
     bool showMinimize = true,
     bool showMaximize = true,
     bool showClose = true,
@@ -108,7 +103,6 @@ class GtkHeaderBar extends StatelessWidget {
     this.titlebarSpace = 4,
     this.height = 47,
     this.themeType,
-    this.systemTheme = GtkColorTheme.adwaita,
     bool showMinimize = true,
     bool showMaximize = true,
     bool showClose = true,
@@ -133,7 +127,6 @@ class GtkHeaderBar extends StatelessWidget {
       padding: padding,
       titlebarSpace: titlebarSpace,
       height: height,
-      systemTheme: systemTheme,
       closeBtn: onClose != null
           ? rawDecoratedWindowButton(
               'close',

--- a/lib/src/widgets/gtk_header_bar_minimal.dart
+++ b/lib/src/widgets/gtk_header_bar_minimal.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import '../utils/utils.dart';
+import 'package:gtk/src/providers/theme_provider.dart';
+import 'package:provider/provider.dart';
 
 class GtkHeaderBarMinimal extends StatelessWidget {
   /// The leading widget for the headerbar
@@ -17,7 +18,7 @@ class GtkHeaderBarMinimal extends StatelessWidget {
 
   final Widget? closeBtn;
 
-  final GtkColorTheme systemTheme;
+  // final GtkColorTheme systemTheme;
 
   /// The height of the headerbar
   final double height;
@@ -44,7 +45,6 @@ class GtkHeaderBarMinimal extends StatelessWidget {
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 47,
-    this.systemTheme = GtkColorTheme.adwaita,
     this.minimizeBtn,
     this.maximizeBtn,
     this.closeBtn,
@@ -61,7 +61,6 @@ class GtkHeaderBarMinimal extends StatelessWidget {
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 47,
-    this.systemTheme = GtkColorTheme.adwaita,
     Widget Function(VoidCallback onTap)? minimizeBtn,
     Widget Function(VoidCallback onTap)? maximizeBtn,
     Widget Function(VoidCallback onTap)? closeBtn,
@@ -83,7 +82,6 @@ class GtkHeaderBarMinimal extends StatelessWidget {
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 47,
-    this.systemTheme = GtkColorTheme.adwaita,
     Widget Function(VoidCallback onTap)? minimizeBtn,
     Widget Function(VoidCallback onTap)? maximizeBtn,
     Widget Function(VoidCallback onTap)? closeBtn,
@@ -99,6 +97,7 @@ class GtkHeaderBarMinimal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Color? border = Provider.of<GnomeThemeProvider>(context).theme.border;
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onPanStart: (_) => onHeaderDrag?.call(),
@@ -107,35 +106,22 @@ class GtkHeaderBarMinimal extends StatelessWidget {
         child: Container(
           decoration: BoxDecoration(
             gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: [
-                getAdaptiveGtkColor(
-                  context,
-                  colorType: GtkColorType.headerBarBackgroundTop,
-                  colorTheme: systemTheme,
-                ),
-                getAdaptiveGtkColor(
-                  context,
-                  colorType: GtkColorType.headerBarBackgroundBottom,
-                  colorTheme: systemTheme,
-                ),
-              ],
-            ),
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Provider.of<GnomeThemeProvider>(context)
+                      .theme
+                      .headerBarBackgroundTop,
+                  Provider.of<GnomeThemeProvider>(context)
+                      .theme
+                      .headerBarBackgroundBottom,
+                ]),
             border: Border(
               top: BorderSide(
-                color: getAdaptiveGtkColor(
-                  context,
-                  colorType: GtkColorType.headerBarTopBorder,
-                  colorTheme: systemTheme,
-                ),
+                color: Theme.of(context).canvasColor,
               ),
               bottom: BorderSide(
-                color: getAdaptiveGtkColor(
-                  context,
-                  colorType: GtkColorType.headerBarBottomBorder,
-                  colorTheme: systemTheme,
-                ),
+                color: border ?? Theme.of(context).canvasColor,
               ),
             ),
           ),

--- a/lib/src/widgets/gtk_sidebar.dart
+++ b/lib/src/widgets/gtk_sidebar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import '../utils/utils.dart';
+import 'package:gtk/src/providers/theme_provider.dart';
+import 'package:provider/provider.dart';
 
 class GtkSidebar extends StatelessWidget {
   /// The current index of the item selected
@@ -54,7 +55,8 @@ class GtkSidebar extends StatelessWidget {
     this.color,
     this.border,
     // Create a vertical list of GtkSidebarItem on demand.
-    required Function(BuildContext context, int index, bool isSelected) itemBuilder,
+    required Function(BuildContext context, int index, bool isSelected)
+        itemBuilder,
     required int itemCount,
     this.controller,
     this.padding,
@@ -62,7 +64,8 @@ class GtkSidebar extends StatelessWidget {
         childrenDelegate = List.generate(
           itemCount,
           (index) => _GtkSidebarItemBuilder(
-            item: (context) => itemBuilder(context, index, currentIndex == index),
+            item: (context) =>
+                itemBuilder(context, index, currentIndex == index),
             isSelected: currentIndex == index,
             onSelected: () => onSelected(index),
           ),
@@ -74,11 +77,15 @@ class GtkSidebar extends StatelessWidget {
     return Container(
         constraints: BoxConstraints(maxWidth: width),
         decoration: BoxDecoration(
-          color: color ?? getAdaptiveGtkColor(context, colorType: GtkColorType.canvas),
+          color: color ??
+              Provider.of<GnomeThemeProvider>(context).theme.themeBgColor,
           border: border ??
               Border(
                 right: BorderSide(
-                  color: getAdaptiveGtkColor(context, colorType: GtkColorType.headerBarBottomBorder).withOpacity(0.4),
+                  color: Provider.of<GnomeThemeProvider>(context)
+                      .theme
+                      .headerBarBottomBorder
+                      .withOpacity(0.4),
                 ),
               ),
         ),
@@ -142,20 +149,36 @@ class _GtkSidebarItemBuilder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var currentItem = item(context);
+    var leading = isSelected
+        ? Theme(
+            data: Provider.of<GnomeThemeProvider>(context).getTheme().copyWith(
+                iconTheme: IconThemeData(
+                    color: isSelected
+                        ? Provider.of<GnomeThemeProvider>(context)
+                            .theme
+                            .themeSelectedBG
+                        : null)),
+            child: currentItem.leading!)
+        : currentItem.leading;
     return InkWell(
       onTap: onSelected,
       child: Container(
-        color: isSelected ? currentItem.selectedColor ?? Theme.of(context).primaryColor : currentItem.unselectedColor,
+        color: Provider.of<GnomeThemeProvider>(context).theme.themeBgColor,
         padding: currentItem.padding,
         child: Row(
           children: [
-            currentItem.leading != null ? currentItem.leading! : const SizedBox(),
+            leading ?? const SizedBox(),
             const SizedBox(width: 12),
             currentItem.labelWidget ??
                 Text(
                   currentItem.label!,
                   style: TextStyle(
-                    color: isSelected ? Colors.white : null,
+                    fontWeight: isSelected ? FontWeight.bold : null,
+                    color: isSelected
+                        ? Provider.of<GnomeThemeProvider>(context)
+                            .theme
+                            .themeSelectedBG
+                        : null,
                     fontSize: 15,
                   ),
                 ),

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -6,3 +6,4 @@ export 'gtk_sidebar.dart';
 export 'gtk_two_pane.dart';
 export 'gtk_view_switcher.dart';
 export 'gtk_view_switcher_tab.dart';
+export 'gtk_app.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   gsettings: ">=0.2.0 <1.0.0"
   popover: ">=0.2.6+2 <1.0.0"
   xdg_directories: ">=0.2.0 <1.0.0"
+  provider: ">=6.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This is a proof of concept to use providers to distribute the theme to all gnome widgets. It is functional for normal flutter widgets, header bar, and side panel.

However, it needs to be extended, but I don't have the time to do the other widgets (and I don't use them). Maybe this PR is a good enough starting point for the others though, it shouldn't be too complicated :).

I have updated the example file to illustrate the use.