### PR TITLE
Simplifed theme use by removing inherite widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Unofficial implementation of GTK Widgets and libadwaita in Flutter. Based on the
 
 ### Usage
 
-- Wrap your `WidgetsApp` / `MaterialApp` / `CupertinoApp` with `GnomeTheme`
-- To get `ThemeData` for `MaterialApp` use `GnomeTheme.of(context).themeData`.
-- To get color from theme you can use `GnomeTheme.of(context).[color]` like `GnomeTheme.of(context).tiles`.
+- To get color from theme you can use `Theme.of(context).[color]` like usual. E.g. `Theme.of(context).tiles`.
 - If you want custom titlebar then you can follow the steps for that on [`bitsdojo_window`](https://pub.dev/packages/bitsdojo_window) package.
 - Following Widgets are currently ported to flutter:
     - `GtkContainer`
@@ -33,10 +31,11 @@ Unofficial implementation of GTK Widgets and libadwaita in Flutter. Based on the
     - `GtkViewSwitcher`
     - `GtkViewSwitcherTab`
 
+See the example app in the `example` folder.
 
 ### Additional information
 
-This package is dependent on 
+This package is dependent on
 - [`popover`](https://pub.dev/packages/popover) for GtkPopover.
 - [`window_decorations`](https://pub.dev/packages/window_decorations) for Window Decorations (doesn't needed if you use `GtkHeaderBarMinimal`)
 

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -1,0 +1,130 @@
+import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'package:flutter/material.dart';
+import 'package:gtk/gtk.dart';
+import 'package:window_decorations/window_decorations.dart';
+
+class MyHomePage extends StatefulWidget {
+  final ValueNotifier<ThemeMode> themeNotifier;
+
+  const MyHomePage({Key? key, required this.themeNotifier}) : super(key: key);
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+  int _currentIndex = 0;
+
+  void _incrementCounter() => setState(() => _counter++);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          GtkHeaderBar.bitsdojo(
+            appWindow: appWindow,
+            windowDecor: windowDecor,
+            leading: GtkHeaderButton(
+                icon: const Icon(Icons.add, size: 15),
+                onPressed: _incrementCounter),
+            center: MediaQuery.of(context).size.width >= 650
+                ? buildViewSwitcher()
+                : const SizedBox(),
+            trailing: Row(
+              children: [
+                GtkPopupMenu(
+                  body: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ListTile(
+                        onTap: () => setState(() {
+                          _counter = 0;
+                          Navigator.of(context).pop();
+                        }),
+                        title: const Text('Reset Counter',
+                            style: TextStyle(fontSize: 15)),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          _currentIndex == 2
+              ? Column(
+                  children: [
+                    GtkContainer(
+                      child: SwitchListTile(
+                          title: Text(
+                            "Dark mode",
+                            style: Theme.of(context).textTheme.bodyText1,
+                          ),
+                          value: widget.themeNotifier.value == ThemeMode.light
+                              ? false
+                              : true,
+                          onChanged: (value) {
+                            widget.themeNotifier.value =
+                                widget.themeNotifier.value == ThemeMode.light
+                                    ? ThemeMode.dark
+                                    : ThemeMode.light;
+                          }),
+                    ),
+                  ],
+                )
+              : _currentIndex == 1
+                  ? Expanded(
+                      child: SingleChildScrollView(
+                        child: Center(
+                          child: GtkContainer(
+                            child: ListView.separated(
+                              shrinkWrap: true,
+                              primary: false,
+                              itemCount: 30,
+                              itemBuilder: (context, index) => ListTile(
+                                title: Text("Index $index"),
+                              ),
+                              separatorBuilder:
+                                  (BuildContext context, int index) => Divider(
+                                color: Theme.of(context).border,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    )
+                  : Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Text(
+                              'You have pushed the add button this many times:'),
+                          Text('$_counter',
+                              style: Theme.of(context).textTheme.headline4),
+                        ],
+                      ),
+                    ),
+        ],
+      ),
+      bottomNavigationBar: MediaQuery.of(context).size.width < 650
+          ? buildViewSwitcher(ViewSwitcherStyle.mobile)
+          : null,
+    );
+  }
+
+  GtkViewSwitcher buildViewSwitcher(
+      [ViewSwitcherStyle viewSwitcherStyle = ViewSwitcherStyle.desktop]) {
+    return GtkViewSwitcher(
+      height: 55,
+      tabs: const [
+        ViewSwitcherData(icon: Icons.near_me_outlined, title: "Counter"),
+        ViewSwitcherData(icon: Icons.list_outlined, title: "List View"),
+        ViewSwitcherData(icon: Icons.settings, title: "Settings")
+      ],
+      style: viewSwitcherStyle,
+      currentIndex: _currentIndex,
+      onViewChanged: (index) => setState(() => _currentIndex = index),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,149 +1,23 @@
-import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:flutter/material.dart';
-import 'package:gtk/gtk.dart';
-import 'package:window_decorations/window_decorations.dart';
+import 'home_page.dart';
 
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
+  final ValueNotifier<ThemeMode> themeNotifier = ValueNotifier(ThemeMode.light);
+
   MyApp({Key? key}) : super(key: key);
 
-  final ValueNotifier<bool> isDark = ValueNotifier(false);
-
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<bool>(
-        valueListenable: isDark,
-        builder: (_, value, ___) {
-          return GnomeTheme(
-            isDark: value,
-            builder: (context) => MaterialApp(
+    return ValueListenableBuilder<ThemeMode>(
+        valueListenable: themeNotifier,
+        builder: (_, ThemeMode currentMode, __) {
+          return MaterialApp(
+              darkTheme: ThemeData.dark(),
               debugShowCheckedModeBanner: false,
-              home: MyHomePage(isDark: isDark),
-              theme: GnomeTheme.of(context).themeData,
-            ),
-          );
+              home: MyHomePage(themeNotifier: themeNotifier),
+              themeMode: currentMode);
         });
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  final ValueNotifier<bool> isDark;
-
-  const MyHomePage({Key? key, required this.isDark}) : super(key: key);
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-  int _currentIndex = 0;
-
-  void _incrementCounter() => setState(() => _counter++);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: Column(
-        children: <Widget>[
-          GtkHeaderBar.bitsdojo(
-            appWindow: appWindow,
-            windowDecor: windowDecor,
-            leading: GtkHeaderButton(
-                icon: const Icon(Icons.add, size: 15),
-                onPressed: _incrementCounter),
-            center: MediaQuery.of(context).size.width >= 650
-                ? buildViewSwitcher()
-                : const SizedBox(),
-            trailing: Row(
-              children: [
-                GtkPopupMenu(
-                  body: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      ListTile(
-                        onTap: () => setState(() {
-                          _counter = 0;
-                          Navigator.of(context).pop();
-                        }),
-                        title: const Text('Reset Counter',
-                            style: TextStyle(fontSize: 15)),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-          _currentIndex == 2
-              ? Column(
-                  children: [
-                    GtkContainer(
-                      child: SwitchListTile(
-                        title: Text(
-                          "Dark mode",
-                          style: Theme.of(context).textTheme.bodyText1,
-                        ),
-                        value: widget.isDark.value,
-                        onChanged: (value) =>
-                            setState(() => widget.isDark.value = value),
-                      ),
-                    ),
-                  ],
-                )
-              : _currentIndex == 1
-                  ? Expanded(
-                      child: SingleChildScrollView(
-                        child: Center(
-                          child: GtkContainer(
-                            child: ListView.separated(
-                              shrinkWrap: true,
-                              primary: false,
-                              itemCount: 30,
-                              itemBuilder: (context, index) => ListTile(
-                                title: Text("Index $index"),
-                              ),
-                              separatorBuilder:
-                                  (BuildContext context, int index) => Divider(
-                                color: GnomeTheme.of(context).border,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    )
-                  : Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const Text(
-                              'You have pushed the add button this many times:'),
-                          Text('$_counter',
-                              style: Theme.of(context).textTheme.headline4),
-                        ],
-                      ),
-                    ),
-        ],
-      ),
-      bottomNavigationBar: MediaQuery.of(context).size.width < 650
-          ? buildViewSwitcher(ViewSwitcherStyle.mobile)
-          : null,
-    );
-  }
-
-  GtkViewSwitcher buildViewSwitcher(
-      [ViewSwitcherStyle viewSwitcherStyle = ViewSwitcherStyle.desktop]) {
-    return GtkViewSwitcher(
-      height: 55,
-      tabs: const [
-        ViewSwitcherData(icon: Icons.near_me_outlined, title: "Counter"),
-        ViewSwitcherData(icon: Icons.list_outlined, title: "List View"),
-        ViewSwitcherData(icon: Icons.settings, title: "Settings")
-      ],
-      style: viewSwitcherStyle,
-      currentIndex: _currentIndex,
-      onViewChanged: (index) => setState(() => _currentIndex = index),
-    );
   }
 }

--- a/lib/src/widgets/gnome_theme.dart
+++ b/lib/src/widgets/gnome_theme.dart
@@ -1,93 +1,29 @@
 import 'package:flutter/material.dart';
 
-class GnomeTheme extends InheritedWidget {
-  final ValueNotifier<Color> primary = ValueNotifier<Color>(Colors.blue);
-
-  /// List rows, tiles
-  final Color tiles;
-
-  /// Menus, popovers
-  final Color menus;
-
-  /// Header bars, active tabs, message dialogs, sidebars
-  final Color sidebars;
-
-  /// View switcher
-  final Color viewSwitcher;
-
-  /// Text, icons color
-  final Color textColor;
-
-  /// Foreground areas, borders
-  final Color fgColor;
-
-  /// Background areas
-  final Color bgColor;
-
-  /// Inactive tabs
-  final Color inactiveTabs;
-
-  final bool isDark;
-
-  late final Color border = fgColor.withOpacity(0.1);
-
-  late final ThemeData themeData = ThemeData(
-    primaryColor: primary.value,
-    canvasColor: bgColor,
-    colorScheme: ColorScheme.fromSwatch().copyWith(
-        secondary: primary.value,
-        primary: primary.value,
-        brightness: isDark ? Brightness.dark : Brightness.light),
-  );
-
-  static GnomeTheme of(BuildContext context) {
-    final GnomeTheme? result =
-        context.dependOnInheritedWidgetOfExactType<GnomeTheme>();
-    assert(result != null,
-        'No GnomeTheme found in context, Please wrap your MaterialApp / CupertinoApp with GnomeTheme');
-    return result!;
-  }
-
-  GnomeTheme({
-    Key? key,
-    required this.isDark,
-    required Widget Function(BuildContext context) builder,
-  })  : tiles = LibAdwaita().tiles[isDark ? 1 : 0],
-        menus = LibAdwaita().menus[isDark ? 1 : 0],
-        sidebars = LibAdwaita().sidebars[isDark ? 1 : 0],
-        viewSwitcher = LibAdwaita().viewSwitcher[isDark ? 1 : 0],
-        textColor = LibAdwaita().textColor[isDark ? 1 : 0],
-        fgColor = LibAdwaita().fgColor[isDark ? 1 : 0],
-        bgColor = LibAdwaita().bgColor[isDark ? 1 : 0],
-        inactiveTabs = LibAdwaita().inactiveTabs[isDark ? 1 : 0],
-        super(key: key, child: Builder(builder: builder));
-
-  @override
-  bool updateShouldNotify(covariant InheritedWidget oldWidget) {
-    return oldWidget.child != child;
-  }
-}
-
 extension _ColorExtension on String {
   Color get fromHex => Color(int.parse('FF${toString()}', radix: 16));
 }
 
-class LibAdwaita {
-  /// Follows the pattern of ```<List>[Light Color, Dark Color]```
-  /// Colors taken from https://gitlab.gnome.org/GNOME/libadwaita/-/issues/267,
-  /// for more info see https://gitlab.gnome.org/GNOME/libadwaita/-/blob/main/src/stylesheet/_colors.scss
-
-  final List<Color> tiles = ['ffffff'.fromHex, '303030'.fromHex];
-  final List<Color> menus = ['ffffff'.fromHex, '383838'.fromHex];
-  final List<Color> sidebars = ['ebebeb'.fromHex, '303030'.fromHex];
-  final List<Color> viewSwitcher = [
-    'd9d9d9'.fromHex,
-    '444444'.fromHex
-  ]; // TO BE UPDATED
-  final List<Color> textColor = [Colors.black, Colors.white];
-  final List<Color> fgColor = [Colors.black26, Colors.white];
-  final List<Color> bgColor = ['fafafa'.fromHex, '242424'.fromHex];
-  final List<Color> inactiveTabs = ['e5e5e5'.fromHex, '292929'.fromHex];
+extension LibAdwaitaTheme on ThemeData {
+  Color get tiles =>
+      brightness == Brightness.light ? 'ffffff'.fromHex : '303030'.fromHex;
+  Color get menus =>
+      brightness == Brightness.light ? 'ffffff'.fromHex : '383838'.fromHex;
+  Color get sidebars =>
+      brightness == Brightness.light ? 'ebebeb'.fromHex : '303030'.fromHex;
+  Color get viewSwitcher =>
+      brightness == Brightness.light ? 'd9d9d9'.fromHex : '444444'.fromHex;
+  Color get textColor =>
+      brightness == Brightness.light ? Colors.black : Colors.white;
+  Color get fgColor =>
+      brightness == Brightness.light ? Colors.black26 : Colors.white;
+  Color get bgColor =>
+      brightness == Brightness.light ? 'fafafa'.fromHex : '242424'.fromHex;
+  Color get inactiveTabs =>
+      brightness == Brightness.light ? 'e5e5e5'.fromHex : '292929'.fromHex;
+  Color get border => brightness == Brightness.light
+      ? Colors.black26.withOpacity(0.1)
+      : Colors.white.withOpacity(0.1);
 }
 
 enum GtkColorType { primary, tiles, menus, sidebar, bgAreas, inactiveTabs }

--- a/lib/src/widgets/gtk_container.dart
+++ b/lib/src/widgets/gtk_container.dart
@@ -24,10 +24,10 @@ class GtkContainer extends StatelessWidget {
       margin: margin,
       padding: padding,
       decoration: BoxDecoration(
-        color: GnomeTheme.of(context).tiles,
+        color: Theme.of(context).tiles,
         borderRadius: BorderRadius.circular(18),
         border: Border.all(
-          color: GnomeTheme.of(context).border,
+          color: Theme.of(context).border,
           width: borderWidth,
         ),
       ),

--- a/lib/src/widgets/gtk_header_bar_minimal.dart
+++ b/lib/src/widgets/gtk_header_bar_minimal.dart
@@ -100,15 +100,20 @@ class GtkHeaderBarMinimal extends StatefulWidget {
 }
 
 class _GtkHeaderBarMinimalState extends State<GtkHeaderBarMinimal> {
-  bool get hasWindowControls => widget.closeBtn != null || widget.minimizeBtn != null || widget.maximizeBtn != null;
+  bool get hasWindowControls =>
+      widget.closeBtn != null ||
+      widget.minimizeBtn != null ||
+      widget.maximizeBtn != null;
 
-  late ValueNotifier<List<String>> seperator = ValueNotifier(["", "minimize,maximize,close"]);
+  late ValueNotifier<List<String>> seperator =
+      ValueNotifier(["", "minimize,maximize,close"]);
 
   @override
   void initState() {
     super.initState();
 
-    late ValueNotifier<String> order = ValueNotifier(":minimize,maximize,close");
+    late ValueNotifier<String> order =
+        ValueNotifier(":minimize,maximize,close");
     updateSep() {
       if (mounted) {
         seperator.value = order.value.split(':');
@@ -146,10 +151,10 @@ class _GtkHeaderBarMinimalState extends State<GtkHeaderBarMinimal> {
         alignment: Alignment.topCenter,
         child: Container(
           decoration: BoxDecoration(
-            color: GnomeTheme.of(context).sidebars,
+            color: Theme.of(context).sidebars,
             border: Border(
-              top: BorderSide(color: GnomeTheme.of(context).bgColor),
-              bottom: BorderSide(color: GnomeTheme.of(context).border),
+              top: BorderSide(color: Theme.of(context).bgColor),
+              bottom: BorderSide(color: Theme.of(context).border),
             ),
           ),
           height: widget.height,
@@ -166,7 +171,8 @@ class _GtkHeaderBarMinimalState extends State<GtkHeaderBarMinimal> {
                         leading: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            if (hasWindowControls && sep[0].split(',').isNotEmpty)
+                            if (hasWindowControls &&
+                                sep[0].split(',').isNotEmpty)
                               SizedBox(width: widget.titlebarSpace),
                             for (var i in sep[0].split(','))
                               if (windowButtons[i] != null) windowButtons[i]!,
@@ -178,7 +184,8 @@ class _GtkHeaderBarMinimalState extends State<GtkHeaderBarMinimal> {
                           mainAxisSize: MainAxisSize.min,
                           children: [
                             widget.trailing,
-                            if (hasWindowControls && sep[1].split(',').isNotEmpty)
+                            if (hasWindowControls &&
+                                sep[1].split(',').isNotEmpty)
                               SizedBox(width: widget.titlebarSpace),
                             for (var i in sep[1].split(','))
                               if (windowButtons[i] != null) windowButtons[i]!,

--- a/lib/src/widgets/gtk_popup_menu.dart
+++ b/lib/src/widgets/gtk_popup_menu.dart
@@ -40,7 +40,7 @@ class _GtkPopupMenuState extends State<GtkPopupMenu> {
           context: context,
           barrierColor: Colors.transparent,
           contentDyOffset: 4,
-          backgroundColor: GnomeTheme.of(context).menus,
+          backgroundColor: Theme.of(context).menus,
           transitionDuration: const Duration(milliseconds: 150),
           bodyBuilder: (context) => SizedBox(child: widget.body),
           direction: PopoverDirection.top,

--- a/lib/src/widgets/gtk_sidebar.dart
+++ b/lib/src/widgets/gtk_sidebar.dart
@@ -76,11 +76,11 @@ class GtkSidebar extends StatelessWidget {
     return Container(
         constraints: BoxConstraints(maxWidth: width),
         decoration: BoxDecoration(
-          color: color ?? GnomeTheme.of(context).sidebars,
+          color: color ?? Theme.of(context).sidebars,
           border: border ??
               Border(
                 right: BorderSide(
-                  color: GnomeTheme.of(context).border,
+                  color: Theme.of(context).border,
                 ),
               ),
         ),
@@ -146,7 +146,7 @@ class _GtkSidebarItemBuilder extends StatelessWidget {
     var currentItem = item(context);
     var leading = IconTheme(
       data: IconThemeData(
-        color: isSelected ? Colors.white : GnomeTheme.of(context).textColor,
+        color: isSelected ? Colors.white : Theme.of(context).textColor,
       ),
       child: currentItem.leading ?? const SizedBox(),
     );

--- a/lib/src/widgets/gtk_view_switcher.dart
+++ b/lib/src/widgets/gtk_view_switcher.dart
@@ -36,13 +36,13 @@ class GtkViewSwitcher extends StatelessWidget {
                 height: height,
                 decoration: BoxDecoration(
                   color: tab.key == currentIndex
-                      ? GnomeTheme.of(context).viewSwitcher
+                      ? Theme.of(context).viewSwitcher
                       : Colors.transparent,
                   border: Border.symmetric(
                     vertical: BorderSide(
                       width: 1,
                       color: tab.key == currentIndex
-                          ? GnomeTheme.of(context).border
+                          ? Theme.of(context).border
                           : Colors.transparent,
                     ),
                   ),

--- a/lib/src/widgets/gtk_view_switcher_tab.dart
+++ b/lib/src/widgets/gtk_view_switcher_tab.dart
@@ -32,7 +32,7 @@ class GtkViewSwitcherTab extends StatelessWidget {
                   Text(
                     data.title!,
                     style: Theme.of(context).textTheme.bodyText2?.copyWith(
-                          color: GnomeTheme.of(context).textColor,
+                          color: Theme.of(context).textColor,
                           fontWeight:
                               isSelected ? FontWeight.bold : FontWeight.normal,
                         ),
@@ -53,7 +53,7 @@ class GtkViewSwitcherTab extends StatelessWidget {
                     data.title!,
                     style: Theme.of(context).textTheme.bodyText2?.copyWith(
                           fontSize: 12,
-                          color: GnomeTheme.of(context).textColor,
+                          color: Theme.of(context).textColor,
                           fontWeight:
                               isSelected ? FontWeight.bold : FontWeight.normal,
                         ),


### PR DESCRIPTION
By extending ThemeData, we can avoid the use of an inherited widget on top of the tree. It simplifies the user interaction with the package since less is needed to use it and the theming flow is consistent with the normal one.